### PR TITLE
fix: make environment copyable including current state

### DIFF
--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -413,3 +413,4 @@ Translational
 translational
 instantiation
 π
+copyable

--- a/safety_gymnasium/builder.py
+++ b/safety_gymnasium/builder.py
@@ -343,19 +343,21 @@ class Builder(gymnasium.Env, gymnasium.utils.EzPickle):
         return self.render_parameters.mode
 
     def __deepcopy__(self, memo) -> Builder:
-        """Make Env copyable."""
-        other = Builder(self.task_id, self.config,
-                        self.render_parameters.mode,
-                        self.render_parameters.width,
-                        self.render_parameters.height,
-                        self.render_parameters.camera_id,
-                        self.render_parameters.camera_name,
-                        )
+        """Make class instance copyable."""
+        other = Builder(
+            self.task_id,
+            self.config,
+            self.render_parameters.mode,
+            self.render_parameters.width,
+            self.render_parameters.height,
+            self.render_parameters.camera_id,
+            self.render_parameters.camera_name,
+        )
         other._seed = self._seed
         other.first_reset = self.first_reset
         other.steps = self.steps
         other.cost = self.cost
         other.terminated = self.terminated
         other.truncated = self.truncated
-        other.task = deepcopy(self.task)
+        other.task = deepcopy(self.task)  # pylint: disable=attribute-defined-outside-init
         return other

--- a/tests/test_deepcopy.py
+++ b/tests/test_deepcopy.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Test copy of environemnts."""
+"""Test copy of environments."""
 
 from copy import deepcopy
 
@@ -88,7 +88,7 @@ def test_equal_outcomes_long(agent_id, env_id, level):
 
     env2 = deepcopy(env1)
 
-    # the copied env should yield the same obervations, reward, etc as the original env when the same staps are taken:
+    # the copied env should yield the same observations, reward, etc as the original env when the same steps are taken:
     for _ in range(32):
         move = env1.action_space.sample()
         obs1, reward1, term1, trunc1, info1 = env1.step(move)


### PR DESCRIPTION
## Description

Adds a `__deepcopy__` Method to builder.py, making it possible to clone an environment including its current state by simply `deepcopy(env)`

## Motivation and Context

For some use cases, backing up the current state or branching off is desireable.
`closes #95 `

- [x] I have raised an issue to propose this change ([required](https://github.com/PKU-Alignment/safety-gymnasium/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/PKU-Alignment/safety-gymnasium/blob/main/CONTRIBUTING.md) guide. (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation accordingly.
- [ ] I have reformatted the code using `make format`. (**required**) <- `make format` crashes on my end, help would be appreciated
- [x] I have checked the code using `make lint`. (**required**) <- reformatting not possible, see above. I did my best to sort imports and fix linting errors manually.
- [x] I have ensured `make test` pass. (**required**)
